### PR TITLE
Set initialValue to true for allowIndex / allowFollow

### DIFF
--- a/src/schema/objects/seo.js
+++ b/src/schema/objects/seo.js
@@ -83,12 +83,13 @@ export const seo = {
           title: 'Indexatie toestaan (index/noindex)',
           name: 'allowIndex',
           type: 'boolean',
-          defaultValue: true,
+          initialValue: true
         },
         {
           title: 'Volgen van links toestaan (follow/nofollow)',
           name: 'allowFollow',
           type: 'boolean',
+          initialValue: true
         },
       ]
     }


### PR DESCRIPTION
Setting the initialValue to `true` will prevent the situation where `allowIndex` / `allowFollow` will result in `noindex` / `nofollow` in `kaliber-sanity-template` (https://github.com/Kaliber/kaliber-sanity-template/blob/main/src/machinery/SeoHead.js#L15)