### PR TITLE
Change order of indexation label in sanity schema

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -80,13 +80,13 @@ export const schema = {
           type: 'string',
         },
         {
-          title: 'Allow indexation (index/noindex)',
+          title: 'Allow indexation (noindex | index)',
           name: 'allowIndex',
           type: 'boolean',
           initialValue: true
         },
         {
-          title: 'Allow following links (follow/nofollow)',
+          title: 'Allow following links (nofollow | follow)',
           name: 'allowFollow',
           type: 'boolean',
           initialValue: true


### PR DESCRIPTION
Als het schuifje aan staan, staat ie aan naar rechts. Dus dat is follow. Een klant vond het onduidelijk dat dit andersom staat. en daar zijn ik en Jaron het mee eens :) 