### PR TITLE
Configurable share image

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,35 @@ defineConfig({
 })
 ```
 
+## Configuration
+
+### Custom Share Image Field
+
+By default, the plugin uses the standard Sanity `image` type with an alt text field for the share image. You can customize this to use a custom image type (e.g., `klbrImage`) or modify the field schema:
+
+```js
+sanityPluginSeo({
+  shareImageField: {
+    title: 'Share image',
+    name: 'shareImage',
+    type: 'klbrImage', // Use your custom image type
+    // No alt field needed for klbrImage
+  }
+})
+```
+
+You can also extend the default field definition to customize specific properties:
+
+```js
+import { sanityPluginSeo, defaultShareImageField } from '@kaliber/sanity-plugin-seo'
+
+sanityPluginSeo({
+  shareImageField: {
+    ...defaultShareImageField,
+    fields: [] // Remove the alt text field while keeping other defaults
+  }
+})
+```
 
 ## Usage
 

--- a/src/sanityPluginSeo.js
+++ b/src/sanityPluginSeo.js
@@ -5,22 +5,10 @@ export { SeoAnalysis } from './components/SeoAnalysis'
 export { typeHasSeo } from './typeHasSeo'
 export { defaultShareImageField }
 
-/**
- * @typedef {Object} SanityPluginSeoOptions
- * @property {Object} [shareImageField] - Custom share image field definition. Override this to use a custom image type like 'klbrImage'.
- * @property {string} [shareImageField.title] - Field title
- * @property {string} [shareImageField.name] - Field name
- * @property {string} [shareImageField.type] - Image type (e.g., 'image', 'klbrImage')
- * @property {Object} [shareImageField.options] - Field options (e.g., { hotspot: true })
- * @property {Array<Object>} [shareImageField.fields] - Nested fields (e.g., alt text field). Set to [] for no fields.
- */
+/** @import { FieldDefinition } from 'sanity' */
 
-/**
- * Sanity plugin for SEO management
- * @param {SanityPluginSeoOptions} [options] - Plugin configuration options
- * @returns {import('sanity').PluginOptions}
- */
 export const sanityPluginSeo = definePlugin(
+  /** @arg {{ shareImageField?: FieldDefinition }} [options] */
   (options = {}) => ({
     name: 'sanity-plugin-seo',
     schema: {

--- a/src/sanityPluginSeo.js
+++ b/src/sanityPluginSeo.js
@@ -1,8 +1,9 @@
 import { definePlugin } from 'sanity'
-import { schema } from './schema'
+import { schema, defaultShareImageField } from './schema'
 
 export { SeoAnalysis } from './components/SeoAnalysis'
 export { typeHasSeo } from './typeHasSeo'
+export { defaultShareImageField }
 
 /**
  * @typedef {Object} SanityPluginSeoOptions

--- a/src/sanityPluginSeo.js
+++ b/src/sanityPluginSeo.js
@@ -4,11 +4,26 @@ import { schema } from './schema'
 export { SeoAnalysis } from './components/SeoAnalysis'
 export { typeHasSeo } from './typeHasSeo'
 
+/**
+ * @typedef {Object} SanityPluginSeoOptions
+ * @property {Object} [shareImageField] - Custom share image field definition. Override this to use a custom image type like 'klbrImage'.
+ * @property {string} [shareImageField.title] - Field title
+ * @property {string} [shareImageField.name] - Field name
+ * @property {string} [shareImageField.type] - Image type (e.g., 'image', 'klbrImage')
+ * @property {Object} [shareImageField.options] - Field options (e.g., { hotspot: true })
+ * @property {Array<Object>} [shareImageField.fields] - Nested fields (e.g., alt text field). Set to [] for no fields.
+ */
+
+/**
+ * Sanity plugin for SEO management
+ * @param {SanityPluginSeoOptions} [options] - Plugin configuration options
+ * @returns {import('sanity').PluginOptions}
+ */
 export const sanityPluginSeo = definePlugin(
-  () => ({
+  (options = {}) => ({
     name: 'sanity-plugin-seo',
     schema: {
-      types: (prev, context) => prev.concat(schema)
+      types: (prev) => prev.concat(schema(options))
     },
   })
 )

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,97 +1,110 @@
-export const schema = {
-  title: 'SEO',
-  name: 'seo',
-  type: 'object',
+/**
+ * Default share image field definition
+ * @type {{title: string, name: string, type: string, options?: Object, fields?: Array<Object>}}
+ */
+const defaultShareImageField = {
+  title: 'Share image',
+  name: 'shareImage',
+  type: 'image',
+  options: {
+    hotspot: true
+  },
   fields: [
     {
-      title: 'Focus keyphrase',
-      name: 'keyphrase',
-      type: 'string',
+      title: 'Alternative description',
+      name: 'alt',
+      type: 'string'
     },
-    {
-      title: 'Synonyms',
-      name: 'synonyms',
-      type: 'string',
-    },
-    {
-      title: 'Mark as cornerstone content',
-      name: 'cornerstone',
-      type: 'boolean',
-    },
-    {
-      title: 'SEO title',
-      name: 'title',
-      type: 'string',
-    },
-    {
-      title: 'Meta description',
-      name: 'description',
-      type: 'text',
-      validation: Rule => Rule.max(156).warning('Try to limit the meta description to 156 characters.')
-    },
-    {
-      title: 'Social',
-      name: 'social',
-      type: 'object',
-      options: {
-        collapsible: true,
-        collapsed: true
-      },
-      fields: [
-        {
-          title: 'Title',
-          name: 'title',
-          type: 'string',
-        },
-        {
-          title: 'Description',
-          name: 'description',
-          type: 'text'
-        },
-        {
-          title: 'Share image',
-          name: 'shareImage',
-          type: 'image',
-          options: {
-            hotspot: true
-          },
-          fields: [
-            {
-              title: 'Alternative description',
-              name: 'alt',
-              type: 'string'
-            },
-          ]
-        }
-      ]
-    },
-    {
-      title: 'Advanced',
-      name: 'advanced',
-      type: 'object',
-      options: {
-        collapsible: true,
-        collapsed: true
-      },
-      fields: [
-        {
-          title: 'Canonical url',
-          name: 'canonicalUrl',
-          type: 'string',
-        },
-        {
-          title: 'Allow indexation (noindex | index)',
-          name: 'allowIndex',
-          type: 'boolean',
-          initialValue: true
-        },
-        {
-          title: 'Allow following links (nofollow | follow)',
-          name: 'allowFollow',
-          type: 'boolean',
-          initialValue: true
-        },
-      ]
-    }
   ]
+}
+
+/**
+ * Generate the SEO schema with custom options
+ * @param {import('./sanityPluginSeo').SanityPluginSeoOptions} [options] - Schema configuration options
+ * @returns {Object} Sanity schema definition
+ */
+export function schema({ shareImageField = defaultShareImageField } = {}) {
+  return {
+    title: 'SEO',
+    name: 'seo',
+    type: 'object',
+    fields: [
+      {
+        title: 'Focus keyphrase',
+        name: 'keyphrase',
+        type: 'string',
+      },
+      {
+        title: 'Synonyms',
+        name: 'synonyms',
+        type: 'string',
+      },
+      {
+        title: 'Mark as cornerstone content',
+        name: 'cornerstone',
+        type: 'boolean',
+      },
+      {
+        title: 'SEO title',
+        name: 'title',
+        type: 'string',
+      },
+      {
+        title: 'Meta description',
+        name: 'description',
+        type: 'text',
+        validation: Rule => Rule.max(156).warning('Try to limit the meta description to 156 characters.')
+      },
+      {
+        title: 'Social',
+        name: 'social',
+        type: 'object',
+        options: {
+          collapsible: true,
+          collapsed: true
+        },
+        fields: [
+          {
+            title: 'Title',
+            name: 'title',
+            type: 'string',
+          },
+          {
+            title: 'Description',
+            name: 'description',
+            type: 'text'
+          },
+          shareImageField
+        ]
+      },
+      {
+        title: 'Advanced',
+        name: 'advanced',
+        type: 'object',
+        options: {
+          collapsible: true,
+          collapsed: true
+        },
+        fields: [
+          {
+            title: 'Canonical url',
+            name: 'canonicalUrl',
+            type: 'string',
+          },
+          {
+            title: 'Allow indexation (noindex | index)',
+            name: 'allowIndex',
+            type: 'boolean',
+            initialValue: true
+          },
+          {
+            title: 'Allow following links (nofollow | follow)',
+            name: 'allowFollow',
+            type: 'boolean',
+            initialValue: true
+          },
+        ]
+      }
+    ]
+  }
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -2,7 +2,7 @@
  * Default share image field definition
  * @type {{title: string, name: string, type: string, options?: Object, fields?: Array<Object>}}
  */
-const defaultShareImageField = {
+export const defaultShareImageField = {
   title: 'Share image',
   name: 'shareImage',
   type: 'image',

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,7 +1,6 @@
-/**
- * Default share image field definition
- * @type {{title: string, name: string, type: string, options?: Object, fields?: Array<Object>}}
- */
+/** @import { FieldDefinition } from 'sanity' */
+
+/** @type {FieldDefinition} */
 export const defaultShareImageField = {
   title: 'Share image',
   name: 'shareImage',
@@ -18,11 +17,7 @@ export const defaultShareImageField = {
   ]
 }
 
-/**
- * Generate the SEO schema with custom options
- * @param {import('./sanityPluginSeo').SanityPluginSeoOptions} [options] - Schema configuration options
- * @returns {Object} Sanity schema definition
- */
+/** @arg {{ shareImageField?: FieldDefinition }} [config] */
 export function schema({ shareImageField = defaultShareImageField } = {}) {
   return {
     title: 'SEO',


### PR DESCRIPTION
Allow customization of the share image field through the shareImageField option in sanityPluginSeo(). This enables projects to use custom image types (e.g., klbrImage) and customize the field schema, such as removing the alt text field when not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin now accepts configuration options to customize the share image field, including support for custom image types and removing the alt field.

* **Documentation**
  * Added a Configuration section with examples showing how to customize the share image field and preserve defaults while omitting specific attributes.

* **Bug Fixes**
  * Restored the full set of SEO fields to ensure complete metadata coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->